### PR TITLE
Update home-assistant-config.js

### DIFF
--- a/home-assistant-config.js
+++ b/home-assistant-config.js
@@ -18,7 +18,8 @@ module.exports = function(RED) {
         node.closing = false;
 
         function connect() {
-            var socket = new ws( node.ssl?"wss":"ws" + "://" + node.host + ":" + node.port + "/api/websocket");
+            var url = (node.ssl ? "wss" : "ws") + "://" + node.host + ":" + node.port + "/api/websocket";
+            var socket = new ws(url);
             node.server = socket;
             socket.setMaxListeners(100);
 


### PR DESCRIPTION
Add parantheses around inline `if` to fix bug where url would resolve to `wss` instead of `wss://[HOST]:[PORT]/api/websocket` when using SSL.